### PR TITLE
Add parameters for asset load and unload handlers

### DIFF
--- a/Packages/UGF.Module.Assets/Runtime/AssetLoadHandler.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetLoadHandler.cs
@@ -2,5 +2,5 @@
 
 namespace UGF.Module.Assets.Runtime
 {
-    public delegate void AssetLoadHandler(string id, Type type);
+    public delegate void AssetLoadHandler(string id, Type type, AssetLoadParameters parameters);
 }

--- a/Packages/UGF.Module.Assets/Runtime/AssetLoadedHandler.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetLoadedHandler.cs
@@ -1,4 +1,4 @@
 ﻿namespace UGF.Module.Assets.Runtime
 {
-    public delegate void AssetLoadedHandler(string id, object asset);
+    public delegate void AssetLoadedHandler(string id, object asset, AssetLoadParameters parameters);
 }

--- a/Packages/UGF.Module.Assets/Runtime/AssetUnloadHandler.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetUnloadHandler.cs
@@ -1,4 +1,4 @@
 ﻿namespace UGF.Module.Assets.Runtime
 {
-    public delegate void AssetUnloadHandler(string id, object asset);
+    public delegate void AssetUnloadHandler(string id, object asset, AssetUnloadParameters parameters);
 }

--- a/Packages/UGF.Module.Assets/Runtime/AssetUnloadedHandler.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetUnloadedHandler.cs
@@ -2,5 +2,5 @@
 
 namespace UGF.Module.Assets.Runtime
 {
-    public delegate void AssetUnloadedHandler(string id, Type type);
+    public delegate void AssetUnloadedHandler(string id, Type type, AssetUnloadParameters parameters);
 }

--- a/Packages/UGF.Module.Assets/Runtime/AssetsModule.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetsModule.cs
@@ -121,11 +121,11 @@ namespace UGF.Module.Assets.Runtime
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            Loading?.Invoke(id, type);
+            Loading?.Invoke(id, type, parameters);
 
             object asset = OnLoad(id, type, parameters);
 
-            Loaded?.Invoke(id, asset);
+            Loaded?.Invoke(id, asset, parameters);
 
             return asset;
         }
@@ -135,11 +135,11 @@ namespace UGF.Module.Assets.Runtime
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            Loading?.Invoke(id, type);
+            Loading?.Invoke(id, type, parameters);
 
             object asset = await OnLoadAsync(id, type, parameters);
 
-            Loaded?.Invoke(id, asset);
+            Loaded?.Invoke(id, asset, parameters);
 
             return asset;
         }
@@ -151,11 +151,11 @@ namespace UGF.Module.Assets.Runtime
 
             Type type = asset.GetType();
 
-            Unloading?.Invoke(id, asset);
+            Unloading?.Invoke(id, asset, parameters);
 
             OnUnload(id, asset, parameters);
 
-            Unloaded?.Invoke(id, type);
+            Unloaded?.Invoke(id, type, parameters);
         }
 
         public async Task UnloadAsync(string id, object asset, AssetUnloadParameters parameters)
@@ -165,11 +165,11 @@ namespace UGF.Module.Assets.Runtime
 
             Type type = asset.GetType();
 
-            Unloading?.Invoke(id, asset);
+            Unloading?.Invoke(id, asset, parameters);
 
             await OnUnloadAsync(id, asset, parameters);
 
-            Unloaded?.Invoke(id, type);
+            Unloaded?.Invoke(id, type, parameters);
         }
 
         protected virtual object OnLoad(string id, Type type, AssetLoadParameters parameters)


### PR DESCRIPTION
- Change `AssetLoadHandler`, `AssetLoadedHandler`, `AssetUnloadHandler` and `AssetUnloadedHandler` signature to have `AssetLoadParameters` and `AssetUnloadParameters` arguments.
- Change `AssetsModule` to pass `AssetLoadParameters` and `AssetUnloadParameters` for all events.