### PR TITLE
Add generic asset loader

### DIFF
--- a/Packages/UGF.Module.Assets/Runtime/AssetGroupAsset.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetGroupAsset.cs
@@ -15,8 +15,20 @@ namespace UGF.Module.Assets.Runtime
 
         protected override IAssetGroup OnBuild()
         {
-            var group = new AssetGroup(m_loader);
+            IAssetGroup group = OnCreateGroup();
 
+            OnPopulateGroup(group);
+
+            return group;
+        }
+
+        protected virtual IAssetGroup OnCreateGroup()
+        {
+            return new AssetGroup(m_loader);
+        }
+
+        protected virtual void OnPopulateGroup(IAssetGroup group)
+        {
             for (int i = 0; i < m_assets.Count; i++)
             {
                 TEntry entry = m_assets[i];
@@ -24,8 +36,6 @@ namespace UGF.Module.Assets.Runtime
 
                 group.Add(entry.Id, info);
             }
-
-            return group;
         }
     }
 }

--- a/Packages/UGF.Module.Assets/Runtime/AssetLoader.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetLoader.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace UGF.Module.Assets.Runtime
+{
+    public abstract class AssetLoader<TGroup, TInfo> : AssetLoaderBase
+        where TGroup : class, IAssetGroup
+        where TInfo : class, IAssetInfo
+    {
+        protected override object OnLoad(IAssetProvider provider, string id, Type type)
+        {
+            var group = (TGroup)provider.GetGroupByAsset(id);
+            var info = group.GetInfo<TInfo>(id);
+
+            return OnLoad(provider, group, info, id, type);
+        }
+
+        protected override Task<object> OnLoadAsync(IAssetProvider provider, string id, Type type)
+        {
+            var group = (TGroup)provider.GetGroupByAsset(id);
+            var info = group.GetInfo<TInfo>(id);
+
+            return OnLoadAsync(provider, group, info, id, type);
+        }
+
+        protected override void OnUnload(IAssetProvider provider, string id, object asset)
+        {
+            var group = (TGroup)provider.GetGroupByAsset(id);
+            var info = group.GetInfo<TInfo>(id);
+
+            OnUnload(provider, group, info, id, asset);
+        }
+
+        protected override Task OnUnloadAsync(IAssetProvider provider, string id, object asset)
+        {
+            var group = (TGroup)provider.GetGroupByAsset(id);
+            var info = group.GetInfo<TInfo>(id);
+
+            return OnUnloadAsync(provider, group, info, id, asset);
+        }
+
+        protected abstract object OnLoad(IAssetProvider provider, TGroup group, TInfo info, string id, Type type);
+        protected abstract Task<object> OnLoadAsync(IAssetProvider provider, TGroup group, TInfo info, string id, Type type);
+        protected abstract void OnUnload(IAssetProvider provider, TGroup group, TInfo info, string id, object asset);
+        protected abstract Task OnUnloadAsync(IAssetProvider provider, TGroup group, TInfo info, string id, object asset);
+    }
+}

--- a/Packages/UGF.Module.Assets/Runtime/AssetLoader.cs.meta
+++ b/Packages/UGF.Module.Assets/Runtime/AssetLoader.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e9f2d9dab9124ccfb9726279cbc58719
+timeCreated: 1604764736

--- a/Packages/UGF.Module.Assets/Runtime/Loaders.Resources/ResourcesLoader.cs
+++ b/Packages/UGF.Module.Assets/Runtime/Loaders.Resources/ResourcesLoader.cs
@@ -5,7 +5,7 @@ using Object = UnityEngine.Object;
 
 namespace UGF.Module.Assets.Runtime.Loaders.Resources
 {
-    public class ResourcesLoader : AssetLoaderBase
+    public class ResourcesLoader : AssetLoader<IAssetGroup, IAssetInfo>
     {
         public bool ProviderAssetUnload { get; }
 
@@ -14,21 +14,15 @@ namespace UGF.Module.Assets.Runtime.Loaders.Resources
             ProviderAssetUnload = providerAssetUnload;
         }
 
-        protected override object OnLoad(IAssetProvider provider, string id, Type type)
+        protected override object OnLoad(IAssetProvider provider, IAssetGroup group, IAssetInfo info, string id, Type type)
         {
-            IAssetGroup group = provider.GetGroupByAsset(id);
-            IAssetInfo info = group.GetInfo(id);
-
             Object asset = UnityEngine.Resources.Load(info.Address, type);
 
             return asset ? asset : throw new NullReferenceException($"Resource load result is null by the specified arguments: id:'{id}', type:'{type}'.");
         }
 
-        protected override async Task<object> OnLoadAsync(IAssetProvider provider, string id, Type type)
+        protected override async Task<object> OnLoadAsync(IAssetProvider provider, IAssetGroup group, IAssetInfo info, string id, Type type)
         {
-            IAssetGroup group = provider.GetGroupByAsset(id);
-            IAssetInfo info = group.GetInfo(id);
-
             ResourceRequest request = UnityEngine.Resources.LoadAsync(info.Address, type);
 
             while (!request.isDone)
@@ -41,12 +35,12 @@ namespace UGF.Module.Assets.Runtime.Loaders.Resources
             return asset ? asset : throw new NullReferenceException($"Resource load result is null by the specified arguments: id:'{id}', type:'{type}'.");
         }
 
-        protected override void OnUnload(IAssetProvider provider, string id, object asset)
+        protected override void OnUnload(IAssetProvider provider, IAssetGroup group, IAssetInfo info, string id, object asset)
         {
             InternalUnload(asset);
         }
 
-        protected override Task OnUnloadAsync(IAssetProvider provider, string id, object asset)
+        protected override Task OnUnloadAsync(IAssetProvider provider, IAssetGroup group, IAssetInfo info, string id, object asset)
         {
             InternalUnload(asset);
 


### PR DESCRIPTION
- Add `AssetGroupAsset<T>.OnCreateGroup` and `OnPopulateGroup` methods to override `IAssetGroup` creation.
- Add `AssetLoader<TGroup, TInfo>` loader class with fetching of `IAssetGroup` and `IAssetInfo` by default.
- Change `ResourcesLoader` to inherit from `AssetLoader<TGroup, TInfo>` class.