### PR TITLE
Add ability to unload asset with track only

### DIFF
--- a/Packages/UGF.Module.Assets/Runtime/AssetUnloadMode.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetUnloadMode.cs
@@ -1,0 +1,18 @@
+﻿namespace UGF.Module.Assets.Runtime
+{
+    public enum AssetUnloadMode
+    {
+        /// <summary>
+        /// Unloads asset with tracking.
+        /// </summary>
+        Track = 0,
+        /// <summary>
+        /// Changes asset track count without unloading.
+        /// </summary>
+        TrackOnly = 1,
+        /// <summary>
+        /// Unloads asset using loader directly without tracking.
+        /// </summary>
+        Direct = 2
+    }
+}

--- a/Packages/UGF.Module.Assets/Runtime/AssetUnloadMode.cs.meta
+++ b/Packages/UGF.Module.Assets/Runtime/AssetUnloadMode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a191d601ef6e43ec9e8b865fe1b9d771
+timeCreated: 1604769006

--- a/Packages/UGF.Module.Assets/Runtime/AssetUnloadParameters.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetUnloadParameters.cs
@@ -6,17 +6,18 @@ namespace UGF.Module.Assets.Runtime
     [Serializable]
     public struct AssetUnloadParameters
     {
-        [SerializeField] private AssetLoadMode m_mode;
+        [SerializeField] private AssetUnloadMode m_mode;
         [SerializeField] private bool m_force;
 
-        public AssetLoadMode Mode { get { return m_mode; } set { m_mode = value; } }
+        public AssetUnloadMode Mode { get { return m_mode; } set { m_mode = value; } }
         public bool Force { get { return m_force; } set { m_force = value; } }
 
-        public static AssetUnloadParameters Default { get; } = new AssetUnloadParameters(AssetLoadMode.Track, false);
-        public static AssetUnloadParameters DefaultForce { get; } = new AssetUnloadParameters(AssetLoadMode.Track, true);
-        public static AssetUnloadParameters Direct { get; } = new AssetUnloadParameters(AssetLoadMode.Direct, false);
+        public static AssetUnloadParameters Default { get; } = new AssetUnloadParameters(AssetUnloadMode.Track, false);
+        public static AssetUnloadParameters DefaultTrackOnly { get; } = new AssetUnloadParameters(AssetUnloadMode.TrackOnly, false);
+        public static AssetUnloadParameters DefaultForce { get; } = new AssetUnloadParameters(AssetUnloadMode.Track, true);
+        public static AssetUnloadParameters Direct { get; } = new AssetUnloadParameters(AssetUnloadMode.Direct, false);
 
-        public AssetUnloadParameters(AssetLoadMode mode, bool force)
+        public AssetUnloadParameters(AssetUnloadMode mode, bool force)
         {
             m_mode = mode;
             m_force = force;

--- a/Packages/UGF.Module.Assets/Runtime/AssetsModule.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetsModule.cs
@@ -232,7 +232,7 @@ namespace UGF.Module.Assets.Runtime
         {
             switch (parameters.Mode)
             {
-                case AssetLoadMode.Track:
+                case AssetUnloadMode.Track:
                 {
                     if (parameters.Force || Tracker.UnTrack(id, out _))
                     {
@@ -242,13 +242,18 @@ namespace UGF.Module.Assets.Runtime
 
                     break;
                 }
-                case AssetLoadMode.Direct:
+                case AssetUnloadMode.TrackOnly:
+                {
+                    Tracker.UnTrack(id, out _);
+                    break;
+                }
+                case AssetUnloadMode.Direct:
                 {
                     UnloadAsset(id, asset);
                     break;
                 }
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(parameters.Mode), $"Invalid asset load mode specified: '{parameters.Mode}'.");
+                    throw new ArgumentOutOfRangeException(nameof(parameters.Mode), $"Invalid asset unload mode specified: '{parameters.Mode}'.");
             }
         }
 
@@ -256,7 +261,7 @@ namespace UGF.Module.Assets.Runtime
         {
             switch (parameters.Mode)
             {
-                case AssetLoadMode.Track:
+                case AssetUnloadMode.Track:
                 {
                     if (parameters.Force || Tracker.UnTrack(id, out _))
                     {
@@ -267,12 +272,18 @@ namespace UGF.Module.Assets.Runtime
 
                     return Task.CompletedTask;
                 }
-                case AssetLoadMode.Direct:
+                case AssetUnloadMode.TrackOnly:
+                {
+                    Tracker.UnTrack(id, out _);
+
+                    return Task.CompletedTask;
+                }
+                case AssetUnloadMode.Direct:
                 {
                     return UnloadAssetAsync(id, asset);
                 }
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(parameters.Mode), $"Invalid asset load mode specified: '{parameters.Mode}'.");
+                    throw new ArgumentOutOfRangeException(nameof(parameters.Mode), $"Invalid asset unload mode specified: '{parameters.Mode}'.");
             }
         }
 


### PR DESCRIPTION
- Add `AssetUnloadMode` with `TrackOnly` option.
- Add `AssetUnloadParameters.DefaultTrackOnly` default parameters for unload with track only.
- Change `AssetUnloadParameters` to use `AssetUnloadMode` instead of `AssetLoadMode`.
- Change `AssetsModule` to work with `AssetUnloadMode` when unloads asset.