### PR TITLE
Add asset info default load and unload parameters

### DIFF
--- a/Assets/UGF.Module.Assets.Runtime.Tests/TestAssetModule.cs
+++ b/Assets/UGF.Module.Assets.Runtime.Tests/TestAssetModule.cs
@@ -47,7 +47,7 @@ namespace UGF.Module.Assets.Runtime.Tests
             application.Initialize();
 
             var module = application.GetModule<IAssetModule>();
-            object asset = module.Load("7ab173a97bcf2bc44b710c33213fa557", typeof(Material), AssetLoadParameters.Empty);
+            object asset = module.Load<Material>("7ab173a97bcf2bc44b710c33213fa557");
 
             Assert.NotNull(asset);
             Assert.IsInstanceOf<Material>(asset);
@@ -71,7 +71,7 @@ namespace UGF.Module.Assets.Runtime.Tests
             application.Initialize();
 
             var module = application.GetModule<IAssetModule>();
-            object asset = module.Load("7ab173a97bcf2bc44b710c33213fa557", typeof(Material), AssetLoadParameters.Empty);
+            object asset = module.Load<Material>("7ab173a97bcf2bc44b710c33213fa557");
 
             Assert.NotNull(asset);
             Assert.IsInstanceOf<Material>(asset);
@@ -98,7 +98,7 @@ namespace UGF.Module.Assets.Runtime.Tests
             application.Initialize();
 
             var module = application.GetModule<IAssetModule>();
-            object asset = module.Load("7ab173a97bcf2bc44b710c33213fa557", typeof(Material), AssetLoadParameters.Empty);
+            object asset = module.Load<Material>("7ab173a97bcf2bc44b710c33213fa557");
 
             Assert.NotNull(asset);
             Assert.IsInstanceOf<Material>(asset);
@@ -127,8 +127,8 @@ namespace UGF.Module.Assets.Runtime.Tests
             application.Initialize();
 
             var module = application.GetModule<IAssetModule>();
-            object asset1 = module.Load("7ab173a97bcf2bc44b710c33213fa557", typeof(Material), AssetLoadParameters.Empty);
-            object asset2 = module.Load("7ab173a97bcf2bc44b710c33213fa557", typeof(Material), AssetLoadParameters.Empty);
+            object asset1 = module.Load<Material>("7ab173a97bcf2bc44b710c33213fa557");
+            object asset2 = module.Load<Material>("7ab173a97bcf2bc44b710c33213fa557");
 
             Assert.NotNull(asset1);
             Assert.NotNull(asset2);
@@ -206,8 +206,8 @@ namespace UGF.Module.Assets.Runtime.Tests
             application.Initialize();
 
             var module = application.GetModule<IAssetModule>();
-            object asset1 = module.Load("7ab173a97bcf2bc44b710c33213fa557", typeof(Material), AssetLoadParameters.Empty);
-            object asset2 = module.Load("7ab173a97bcf2bc44b710c33213fa557", typeof(Material), AssetLoadParameters.Empty);
+            object asset1 = module.Load<Material>("7ab173a97bcf2bc44b710c33213fa557");
+            object asset2 = module.Load<Material>("7ab173a97bcf2bc44b710c33213fa557");
 
             Assert.NotNull(asset1);
             Assert.NotNull(asset2);

--- a/Packages/UGF.Module.Assets/Runtime/AssetLoaderBase.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetLoaderBase.cs
@@ -17,6 +17,10 @@ namespace UGF.Module.Assets.Runtime
 
         public object Load(string id, Type type, IContext context)
         {
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
             return OnLoad(id, type, context);
         }
 
@@ -32,6 +36,10 @@ namespace UGF.Module.Assets.Runtime
 
         public Task<object> LoadAsync(string id, Type type, IContext context)
         {
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
             return OnLoadAsync(id, type, context);
         }
 
@@ -47,6 +55,10 @@ namespace UGF.Module.Assets.Runtime
 
         public void Unload(string id, object asset, IContext context)
         {
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (asset == null) throw new ArgumentNullException(nameof(asset));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
             OnUnload(id, asset, context);
         }
 
@@ -62,6 +74,10 @@ namespace UGF.Module.Assets.Runtime
 
         public Task UnloadAsync(string id, object asset, IContext context)
         {
+            if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
+            if (asset == null) throw new ArgumentNullException(nameof(asset));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
             return OnUnloadAsync(id, asset, DefaultUnloadParameters, context);
         }
 

--- a/Packages/UGF.Module.Assets/Runtime/AssetLoaderBase.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetLoaderBase.cs
@@ -6,6 +6,20 @@ namespace UGF.Module.Assets.Runtime
 {
     public abstract class AssetLoaderBase : IAssetLoader
     {
+        public IAssetLoadParameters DefaultLoadParameters { get; }
+        public IAssetUnloadParameters DefaultUnloadParameters { get; }
+
+        protected AssetLoaderBase(IAssetLoadParameters defaultLoadParameters, IAssetUnloadParameters defaultUnloadParameters)
+        {
+            DefaultLoadParameters = defaultLoadParameters ?? throw new ArgumentNullException(nameof(defaultLoadParameters));
+            DefaultUnloadParameters = defaultUnloadParameters ?? throw new ArgumentNullException(nameof(defaultUnloadParameters));
+        }
+
+        public object Load(string id, Type type, IContext context)
+        {
+            return OnLoad(id, type, context);
+        }
+
         public object Load(string id, Type type, IAssetLoadParameters parameters, IContext context)
         {
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
@@ -14,6 +28,11 @@ namespace UGF.Module.Assets.Runtime
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             return OnLoad(id, type, parameters, context);
+        }
+
+        public Task<object> LoadAsync(string id, Type type, IContext context)
+        {
+            return OnLoadAsync(id, type, context);
         }
 
         public Task<object> LoadAsync(string id, Type type, IAssetLoadParameters parameters, IContext context)
@@ -26,6 +45,11 @@ namespace UGF.Module.Assets.Runtime
             return OnLoadAsync(id, type, parameters, context);
         }
 
+        public void Unload(string id, object asset, IContext context)
+        {
+            OnUnload(id, asset, context);
+        }
+
         public void Unload(string id, object asset, IAssetUnloadParameters parameters, IContext context)
         {
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
@@ -36,6 +60,11 @@ namespace UGF.Module.Assets.Runtime
             OnUnload(id, asset, parameters, context);
         }
 
+        public Task UnloadAsync(string id, object asset, IContext context)
+        {
+            return OnUnloadAsync(id, asset, DefaultUnloadParameters, context);
+        }
+
         public Task UnloadAsync(string id, object asset, IAssetUnloadParameters parameters, IContext context)
         {
             if (string.IsNullOrEmpty(id)) throw new ArgumentException("Value cannot be null or empty.", nameof(id));
@@ -44,6 +73,26 @@ namespace UGF.Module.Assets.Runtime
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             return OnUnloadAsync(id, asset, parameters, context);
+        }
+
+        protected virtual object OnLoad(string id, Type type, IContext context)
+        {
+            return OnLoad(id, type, DefaultLoadParameters, context);
+        }
+
+        protected virtual Task<object> OnLoadAsync(string id, Type type, IContext context)
+        {
+            return OnLoadAsync(id, type, DefaultLoadParameters, context);
+        }
+
+        protected virtual void OnUnload(string id, object asset, IContext context)
+        {
+            OnUnload(id, asset, DefaultUnloadParameters, context);
+        }
+
+        protected virtual Task OnUnloadAsync(string id, object asset, IContext context)
+        {
+            return OnUnloadAsync(id, asset, DefaultUnloadParameters, context);
         }
 
         protected abstract object OnLoad(string id, Type type, IAssetLoadParameters parameters, IContext context);

--- a/Packages/UGF.Module.Assets/Runtime/AssetLoader`1.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetLoader`1.cs
@@ -2,5 +2,12 @@
 {
     public abstract class AssetLoader<TInfo> : AssetLoader<TInfo, IAssetLoadParameters, IAssetUnloadParameters> where TInfo : class, IAssetInfo
     {
+        protected AssetLoader() : base(AssetLoadParameters.Empty, AssetUnloadParameters.Empty)
+        {
+        }
+
+        protected AssetLoader(IAssetLoadParameters defaultLoadParameters, IAssetUnloadParameters defaultUnloadParameters) : base(defaultLoadParameters, defaultUnloadParameters)
+        {
+        }
     }
 }

--- a/Packages/UGF.Module.Assets/Runtime/AssetLoader`3.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetLoader`3.cs
@@ -10,6 +10,10 @@ namespace UGF.Module.Assets.Runtime
         where TLoadParameters : class, IAssetLoadParameters
         where TUnloadParameters : class, IAssetUnloadParameters
     {
+        protected AssetLoader(IAssetLoadParameters defaultLoadParameters, IAssetUnloadParameters defaultUnloadParameters) : base(defaultLoadParameters, defaultUnloadParameters)
+        {
+        }
+
         protected override object OnLoad(string id, Type type, IAssetLoadParameters parameters, IContext context)
         {
             var provider = context.Get<IProvider<string, IAssetInfo>>();

--- a/Packages/UGF.Module.Assets/Runtime/AssetLoader`3.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetLoader`3.cs
@@ -10,7 +10,7 @@ namespace UGF.Module.Assets.Runtime
         where TLoadParameters : class, IAssetLoadParameters
         where TUnloadParameters : class, IAssetUnloadParameters
     {
-        protected AssetLoader(IAssetLoadParameters defaultLoadParameters, IAssetUnloadParameters defaultUnloadParameters) : base(defaultLoadParameters, defaultUnloadParameters)
+        protected AssetLoader(TLoadParameters defaultLoadParameters, TUnloadParameters defaultUnloadParameters) : base(defaultLoadParameters, defaultUnloadParameters)
         {
         }
 

--- a/Packages/UGF.Module.Assets/Runtime/AssetModule.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetModule.cs
@@ -63,7 +63,7 @@ namespace UGF.Module.Assets.Runtime
             {
                 string id = Description.PreloadAssets[i];
 
-                this.Load<Object>(id, AssetLoadParameters.Empty);
+                this.Load<Object>(id);
             }
 
             Log.Debug("Assets Module preload", new
@@ -78,7 +78,7 @@ namespace UGF.Module.Assets.Runtime
             {
                 string id = Description.PreloadAssetsAsync[i];
 
-                await this.LoadAsync<Object>(id, AssetLoadParameters.Empty);
+                await this.LoadAsync<Object>(id);
             }
 
             Log.Debug("Assets Module preload async", new
@@ -102,7 +102,7 @@ namespace UGF.Module.Assets.Runtime
                 {
                     KeyValuePair<string, AssetTrack> pair = Tracker.Entries.First();
 
-                    Unload(pair.Key, pair.Value.Asset, AssetUnloadParameters.Empty);
+                    this.Unload(pair.Key, pair.Value.Asset);
                 }
             }
 

--- a/Packages/UGF.Module.Assets/Runtime/AssetModuleExtensions.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetModuleExtensions.cs
@@ -5,26 +5,9 @@ namespace UGF.Module.Assets.Runtime
 {
     public static class AssetModuleExtensions
     {
-        public static IAssetUnloadParameters GetDefaultUnloadParametersByAsset(this IAssetModule assetModule, string id)
-        {
-            return TryGetDefaultUnloadParametersByAsset(assetModule, id, out IAssetUnloadParameters parameters) ? parameters : throw new ArgumentException($"Unload parameters not found by the specified asset id: '{id}'.");
-        }
-
-        public static bool TryGetDefaultUnloadParametersByAsset(this IAssetModule assetModule, string id, out IAssetUnloadParameters parameters)
-        {
-            if (TryGetLoaderByAsset(assetModule, id, out IAssetLoader loader))
-            {
-                parameters = loader.DefaultUnloadParameters;
-                return true;
-            }
-
-            parameters = null;
-            return false;
-        }
-
         public static IAssetLoadParameters GetDefaultLoadParametersByAsset(this IAssetModule assetModule, string id)
         {
-            return TryGetDefaultLoadParametersByAsset(assetModule, id, out IAssetLoadParameters parameters) ? parameters : throw new ArgumentException($"Load parameters not found by the specified asset id: '{id}'.");
+            return TryGetDefaultLoadParametersByAsset(assetModule, id, out IAssetLoadParameters parameters) ? parameters : throw new ArgumentException($"Asset load parameters not found by the specified asset id: '{id}'.");
         }
 
         public static bool TryGetDefaultLoadParametersByAsset(this IAssetModule assetModule, string id, out IAssetLoadParameters parameters)
@@ -32,6 +15,23 @@ namespace UGF.Module.Assets.Runtime
             if (TryGetLoaderByAsset(assetModule, id, out IAssetLoader loader))
             {
                 parameters = loader.DefaultLoadParameters;
+                return true;
+            }
+
+            parameters = null;
+            return false;
+        }
+
+        public static IAssetUnloadParameters GetDefaultUnloadParametersByAsset(this IAssetModule assetModule, string id)
+        {
+            return TryGetDefaultUnloadParametersByAsset(assetModule, id, out IAssetUnloadParameters parameters) ? parameters : throw new ArgumentException($"Asset unload parameters not found by the specified asset id: '{id}'.");
+        }
+
+        public static bool TryGetDefaultUnloadParametersByAsset(this IAssetModule assetModule, string id, out IAssetUnloadParameters parameters)
+        {
+            if (TryGetLoaderByAsset(assetModule, id, out IAssetLoader loader))
+            {
+                parameters = loader.DefaultUnloadParameters;
                 return true;
             }
 
@@ -70,10 +70,22 @@ namespace UGF.Module.Assets.Runtime
             return (T)await assetModule.LoadAsync(id, typeof(T), parameters);
         }
 
+        public static object Load(this IAssetModule assetModule, string id, Type type)
+        {
+            IAssetLoadParameters parameters = GetDefaultLoadParametersByAsset(assetModule, id);
+
+            return assetModule.Load(id, type, parameters);
+        }
+
+        public static Task<object> LoadAsync(this IAssetModule assetModule, string id, Type type)
+        {
+            IAssetLoadParameters parameters = GetDefaultLoadParametersByAsset(assetModule, id);
+
+            return assetModule.LoadAsync(id, type, parameters);
+        }
+
         public static void Unload(this IAssetModule assetModule, string id, object asset)
         {
-            if (assetModule == null) throw new ArgumentNullException(nameof(assetModule));
-
             IAssetUnloadParameters parameters = GetDefaultUnloadParametersByAsset(assetModule, id);
 
             assetModule.Unload(id, asset, parameters);
@@ -81,8 +93,6 @@ namespace UGF.Module.Assets.Runtime
 
         public static Task UnloadAsync(this IAssetModule assetModule, string id, object asset)
         {
-            if (assetModule == null) throw new ArgumentNullException(nameof(assetModule));
-
             IAssetUnloadParameters parameters = GetDefaultUnloadParametersByAsset(assetModule, id);
 
             return assetModule.UnloadAsync(id, asset, parameters);

--- a/Packages/UGF.Module.Assets/Runtime/AssetModuleExtensions.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetModuleExtensions.cs
@@ -5,6 +5,40 @@ namespace UGF.Module.Assets.Runtime
 {
     public static class AssetModuleExtensions
     {
+        public static IAssetUnloadParameters GetDefaultUnloadParametersByAsset(this IAssetModule assetModule, string id)
+        {
+            return TryGetDefaultUnloadParametersByAsset(assetModule, id, out IAssetUnloadParameters parameters) ? parameters : throw new ArgumentException($"Unload parameters not found by the specified asset id: '{id}'.");
+        }
+
+        public static bool TryGetDefaultUnloadParametersByAsset(this IAssetModule assetModule, string id, out IAssetUnloadParameters parameters)
+        {
+            if (TryGetLoaderByAsset(assetModule, id, out IAssetLoader loader))
+            {
+                parameters = loader.DefaultUnloadParameters;
+                return true;
+            }
+
+            parameters = null;
+            return false;
+        }
+
+        public static IAssetLoadParameters GetDefaultLoadParametersByAsset(this IAssetModule assetModule, string id)
+        {
+            return TryGetDefaultLoadParametersByAsset(assetModule, id, out IAssetLoadParameters parameters) ? parameters : throw new ArgumentException($"Load parameters not found by the specified asset id: '{id}'.");
+        }
+
+        public static bool TryGetDefaultLoadParametersByAsset(this IAssetModule assetModule, string id, out IAssetLoadParameters parameters)
+        {
+            if (TryGetLoaderByAsset(assetModule, id, out IAssetLoader loader))
+            {
+                parameters = loader.DefaultLoadParameters;
+                return true;
+            }
+
+            parameters = null;
+            return false;
+        }
+
         public static IAssetLoader GetLoaderByAsset(this IAssetModule assetModule, string id)
         {
             return TryGetLoaderByAsset(assetModule, id, out IAssetLoader loader) ? loader : throw new ArgumentException($"Asset loader not found by the specified asset id: '{id}'.");
@@ -18,22 +52,28 @@ namespace UGF.Module.Assets.Runtime
             return assetModule.Assets.TryGet(id, out IAssetInfo asset) && assetModule.Loaders.TryGet(asset.LoaderId, out loader);
         }
 
-        public static T Load<T>(this IAssetModule assetModule, string id, IAssetLoadParameters parameters) where T : class
+        public static T Load<T>(this IAssetModule assetModule, string id, IAssetLoadParameters parameters = null) where T : class
         {
             if (assetModule == null) throw new ArgumentNullException(nameof(assetModule));
+
+            parameters ??= GetDefaultLoadParametersByAsset(assetModule, id);
 
             return (T)assetModule.Load(id, typeof(T), parameters);
         }
 
-        public static async Task<T> LoadAsync<T>(this IAssetModule assetModule, string id, IAssetLoadParameters parameters) where T : class
+        public static async Task<T> LoadAsync<T>(this IAssetModule assetModule, string id, IAssetLoadParameters parameters = null) where T : class
         {
             if (assetModule == null) throw new ArgumentNullException(nameof(assetModule));
+
+            parameters ??= GetDefaultLoadParametersByAsset(assetModule, id);
 
             return (T)await assetModule.LoadAsync(id, typeof(T), parameters);
         }
 
-        public static void UnloadForce(this IAssetModule assetModule, string id, IAssetUnloadParameters parameters)
+        public static void UnloadForce(this IAssetModule assetModule, string id, IAssetUnloadParameters parameters = null)
         {
+            parameters ??= GetDefaultUnloadParametersByAsset(assetModule, id);
+
             AssetTrack track = assetModule.Tracker.Get(id);
             IAssetLoader loader = GetLoaderByAsset(assetModule, id);
 
@@ -42,8 +82,10 @@ namespace UGF.Module.Assets.Runtime
             loader.Unload(id, track.Asset, parameters, assetModule.Context);
         }
 
-        public static Task UnloadForceAsync(this IAssetModule assetModule, string id, IAssetUnloadParameters parameters)
+        public static Task UnloadForceAsync(this IAssetModule assetModule, string id, IAssetUnloadParameters parameters = null)
         {
+            parameters ??= GetDefaultUnloadParametersByAsset(assetModule, id);
+
             AssetTrack track = assetModule.Tracker.Get(id);
             IAssetLoader loader = GetLoaderByAsset(assetModule, id);
 

--- a/Packages/UGF.Module.Assets/Runtime/AssetModuleExtensions.cs
+++ b/Packages/UGF.Module.Assets/Runtime/AssetModuleExtensions.cs
@@ -70,6 +70,24 @@ namespace UGF.Module.Assets.Runtime
             return (T)await assetModule.LoadAsync(id, typeof(T), parameters);
         }
 
+        public static void Unload(this IAssetModule assetModule, string id, object asset)
+        {
+            if (assetModule == null) throw new ArgumentNullException(nameof(assetModule));
+
+            IAssetUnloadParameters parameters = GetDefaultUnloadParametersByAsset(assetModule, id);
+
+            assetModule.Unload(id, asset, parameters);
+        }
+
+        public static Task UnloadAsync(this IAssetModule assetModule, string id, object asset)
+        {
+            if (assetModule == null) throw new ArgumentNullException(nameof(assetModule));
+
+            IAssetUnloadParameters parameters = GetDefaultUnloadParametersByAsset(assetModule, id);
+
+            return assetModule.UnloadAsync(id, asset, parameters);
+        }
+
         public static void UnloadForce(this IAssetModule assetModule, string id, IAssetUnloadParameters parameters = null)
         {
             parameters ??= GetDefaultUnloadParametersByAsset(assetModule, id);

--- a/Packages/UGF.Module.Assets/Runtime/IAssetLoader.cs
+++ b/Packages/UGF.Module.Assets/Runtime/IAssetLoader.cs
@@ -6,9 +6,16 @@ namespace UGF.Module.Assets.Runtime
 {
     public interface IAssetLoader
     {
+        IAssetLoadParameters DefaultLoadParameters { get; }
+        IAssetUnloadParameters DefaultUnloadParameters { get; }
+
+        object Load(string id, Type type, IContext context);
         object Load(string id, Type type, IAssetLoadParameters parameters, IContext context);
+        Task<object> LoadAsync(string id, Type type, IContext context);
         Task<object> LoadAsync(string id, Type type, IAssetLoadParameters parameters, IContext context);
+        void Unload(string id, object asset, IContext context);
         void Unload(string id, object asset, IAssetUnloadParameters parameters, IContext context);
+        Task UnloadAsync(string id, object asset, IContext context);
         Task UnloadAsync(string id, object asset, IAssetUnloadParameters parameters, IContext context);
     }
 }


### PR DESCRIPTION
- Add `IAssetLoadParameters` and `IAssetUnloadParameters` properties for `IAssetLoader` interface and class implementations.
- Add `Load`, `LoadAsync`, `Unload` and `UnloadAsync` methods without parameters argument for `IAssetLoader` interface and class implementations which use default load and unload parameters from loader.
- Add implementation of default load and unload parameters and methods overloads as virtual methods for `AssetLoaderBase` class.
- Add `TryGetDefaultLoadParametersByAsset`, `GetDefaultLoadParametersByAsset`, `TryGetDefaultUnloadParametersByAsset` and `GetDefaultUnloadParametersByAsset` extension methods for `IAssetModule` interface to get default load and unload parameters of loader by the specified asset id.
- Add `Load`, `LoadAsync`, `Unload` and `UnloadAsync` extension methods for `IAssetModule` interface without load and unload parameters as argument which use default parameters of loader.
- Change `AssetModule` to load and unload assets on initialization and uninitialization using default parameters from loaders.
- Change `Load<T>` and `LoadAsync<T>` extension methods for `IAssetModule` to make load parameters optional, default parameters from loader will be used instead.
- Change `UnloadForce` and `UnloadForceAsync` extension methods for `IAssetModule` to make unload parameters optional, default parameters from loader will be used instead.