### PR TITLE
Add refresh all groups in project settings

### DIFF
--- a/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorBuildPreprocessor.cs
+++ b/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorBuildPreprocessor.cs
@@ -14,7 +14,7 @@ namespace UGF.Module.Assets.Editor.Loaders.Resources
 
             if (settings.Exists() && settings.GetData().UpdateAllGroupsOnBuild)
             {
-                ResourcesAssetEditorUtility.UpdateAllAssetGroups();
+                ResourcesAssetEditorUtility.UpdateAssetGroupAll();
             }
         }
     }

--- a/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorProgress.cs
+++ b/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorProgress.cs
@@ -1,0 +1,28 @@
+﻿using UnityEditor;
+
+namespace UGF.Module.Assets.Editor.Loaders.Resources
+{
+    internal static class ResourcesAssetEditorProgress
+    {
+        public static void StartUpdateAssetGroupAll()
+        {
+            int progressId = Progress.Start("Update All Resources Assets Group", string.Empty, Progress.Options.Indefinite);
+
+            try
+            {
+                ResourcesAssetEditorUtility.UpdateAssetGroupAll();
+
+                Progress.Finish(progressId);
+            }
+            catch
+            {
+                Progress.Finish(progressId, Progress.Status.Failed);
+                throw;
+            }
+            finally
+            {
+                AssetDatabase.SaveAssets();
+            }
+        }
+    }
+}

--- a/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorProgress.cs.meta
+++ b/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorProgress.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 98f39a101ccf47b097dc2192da8b6877
+timeCreated: 1633539233

--- a/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorSettingsDataEditor.cs
@@ -1,0 +1,47 @@
+﻿using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.Module.Assets.Editor.Loaders.Resources
+{
+    [CustomEditor(typeof(ResourcesAssetEditorSettingsData), true)]
+    internal class ResourcesAssetEditorSettingsDataEditor : UnityEditor.Editor
+    {
+        private SerializedProperty m_propertyUpdateAllGroupsOnBuild;
+        private Styles m_styles;
+
+        private class Styles
+        {
+            public GUIContent RefreshAllContent { get; } = new GUIContent("Refresh All", "Refresh all groups in project to update address for each entry.");
+        }
+
+        private void OnEnable()
+        {
+            m_propertyUpdateAllGroupsOnBuild = serializedObject.FindProperty("m_updateAllGroupsOnBuild");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            m_styles ??= new Styles();
+
+            using (new SerializedObjectUpdateScope(serializedObject))
+            {
+                EditorGUILayout.PropertyField(m_propertyUpdateAllGroupsOnBuild);
+            }
+
+            EditorGUILayout.Space();
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                GUILayout.FlexibleSpace();
+
+                if (GUILayout.Button(m_styles.RefreshAllContent))
+                {
+                    ResourcesAssetEditorProgress.StartUpdateAssetGroupAll();
+                }
+
+                EditorGUILayout.Space();
+            }
+        }
+    }
+}

--- a/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorSettingsDataEditor.cs.meta
+++ b/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorSettingsDataEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e119ea82749743b182a46bc5fff88042
+timeCreated: 1633539375

--- a/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorUtility.Deprecated.cs
+++ b/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorUtility.Deprecated.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using UGF.Module.Assets.Runtime.Loaders.Resources;
+using UnityEditor;
+
+namespace UGF.Module.Assets.Editor.Loaders.Resources
+{
+    public static partial class ResourcesAssetEditorUtility
+    {
+        [Obsolete("UpdateAllAssetGroups has been deprecated. Use UpdateAssetGroupAll method instead.")]
+        public static void UpdateAllAssetGroups()
+        {
+            ResourcesAssetEditorProgress.StartUpdateAssetGroupAll();
+        }
+    }
+}

--- a/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorUtility.Deprecated.cs.meta
+++ b/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorUtility.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a1165f00f7434f619318296b8a5b7c23
+timeCreated: 1633539226

--- a/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorUtility.cs
+++ b/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetEditorUtility.cs
@@ -6,7 +6,7 @@ using Object = UnityEngine.Object;
 
 namespace UGF.Module.Assets.Editor.Loaders.Resources
 {
-    public static class ResourcesAssetEditorUtility
+    public static partial class ResourcesAssetEditorUtility
     {
         public static bool IsAssetGroupHasMissingEntries(ResourcesAssetGroupAsset group)
         {
@@ -34,6 +34,25 @@ namespace UGF.Module.Assets.Editor.Loaders.Resources
             return false;
         }
 
+        public static void UpdateAssetGroupAll()
+        {
+            string[] guids = AssetDatabase.FindAssets($"t:{nameof(ResourcesAssetGroupAsset)}");
+
+            for (int i = 0; i < guids.Length; i++)
+            {
+                string guid = guids[i];
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                var asset = AssetDatabase.LoadAssetAtPath<ResourcesAssetGroupAsset>(path);
+
+                if (asset != null)
+                {
+                    UpdateAssetGroupEntries(asset);
+
+                    EditorUtility.SetDirty(asset);
+                }
+            }
+        }
+
         public static void UpdateAssetGroupEntries(ResourcesAssetGroupAsset group)
         {
             if (group == null) throw new ArgumentNullException(nameof(group));
@@ -53,43 +72,6 @@ namespace UGF.Module.Assets.Editor.Loaders.Resources
                         group.Assets[i] = entry;
                     }
                 }
-            }
-        }
-
-        public static void UpdateAllAssetGroups()
-        {
-            int progressId = Progress.Start("Update All Resources Assets Group");
-
-            try
-            {
-                string[] guids = AssetDatabase.FindAssets($"t:{nameof(ResourcesAssetGroupAsset)}");
-
-                for (int i = 0; i < guids.Length; i++)
-                {
-                    Progress.Report(progressId, i, guids.Length);
-
-                    string guid = guids[i];
-                    string path = AssetDatabase.GUIDToAssetPath(guid);
-                    var asset = AssetDatabase.LoadAssetAtPath<ResourcesAssetGroupAsset>(path);
-
-                    if (asset != null)
-                    {
-                        UpdateAssetGroupEntries(asset);
-
-                        EditorUtility.SetDirty(asset);
-                    }
-                }
-
-                Progress.Finish(progressId);
-            }
-            catch
-            {
-                Progress.Finish(progressId, Progress.Status.Failed);
-                throw;
-            }
-            finally
-            {
-                AssetDatabase.SaveAssets();
             }
         }
     }

--- a/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetGroupAssetEditor.cs
+++ b/Packages/UGF.Module.Assets/Editor/Loaders.Resources/ResourcesAssetGroupAssetEditor.cs
@@ -59,7 +59,7 @@ namespace UGF.Module.Assets.Editor.Loaders.Resources
 
                 if (GUILayout.Button(m_styles.RefreshAllContent))
                 {
-                    ResourcesAssetEditorUtility.UpdateAllAssetGroups();
+                    ResourcesAssetEditorProgress.StartUpdateAssetGroupAll();
                 }
 
                 if (GUILayout.Button(m_styles.RefreshContent))

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "3.0.7",
-    "com.unity.test-framework": "1.1.24"
+    "com.unity.test-framework": "1.1.29"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -103,7 +103,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.24",
+      "version": "1.1.29",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.7f1
-m_EditorVersionWithRevision: 2021.1.7f1 (d91830b65d9b)
+m_EditorVersion: 2021.1.19f1
+m_EditorVersionWithRevision: 2021.1.19f1 (5f5eb8bbdc25)


### PR DESCRIPTION
- Add `Refresh All` button in project settings to refresh all groups in the project.
- Deprecate `ResourcesAssetEditorUtility.UpdateAllAssetGroups()` method, use `UpdateAssetGroupAll()` method instead.